### PR TITLE
補完 5335fa8 漏掉的 5 處 auto-collect 殘留引用

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,6 @@ python scripts/lcu_collector.py merge-db --out-db data/lcu/games_merged.db data/
 python scripts/lcu_collector.py dataset --queue 2400 --patch-prefix 16.9 --topn 20 --min-games 30
 python scripts/lcu_collector.py stats --queue 2400 --patch-prefix 16.9 --out-dir data/stats/mayhem_16_9
 python scripts/lcu_collector.py family-stats --queue 2400
-python scripts/lcu_collector.py auto-collect --rounds 20 --target-games 500 --max-players 1000 --opgg-tier platinum --opgg-tier gold --opgg-pages-per-round 2
 python scripts/lcu_collector.py export --out data/raw/lcu_games.parquet
 python scripts/lcu_collector.py export --queue 2400 --out data/raw/mayhem_games.parquet
 ```
@@ -100,7 +99,7 @@ Database: `data/lcu/games.db` (SQLite) — safe to interrupt and resume.
 - `manual_riot_id`（OPGG）**是** productive seed family — 同一次量測 199 captures / 2,385 puuids、blue_wr=0.528。**舊** log 看到的「manual yield=0」其實是 attribution bug（transitive captures 被歸到 immediate `match` source 而非 root family），已於 `crawl_seen.seed_family` 修；別根據舊結論判 OPGG seed 沒用。
 - `suggested players` 是下一個高價值 seed family，但只在 `gameflow phase=Lobby` 時存在；若 phase=`None` 且 `suggested_players=0`，下一個最有價值的 move 是使用者先進 lobby。
 - LCU 所謂「憑證過期」通常不是 cert 真過期，而是 League 重啟後 `port/token` 換掉或 `/lol-*` 尚未 ready；先重抓 credentials 與 `current_summoner`，不要先怪 cert。
-- **Persisted backoff 會卡 OPGG seeding**：`source_family_backoff_until` 寫進 `crawl_runtime_state` 後，下一個 snowball 啟動時讀回，會印 `[snowball] startup skip  source=manual_riot_id  reason=backoff` 並讓整批 OPGG seed 不入 queue（newly_seeded=0）。先 `DELETE FROM crawl_runtime_state WHERE state_key LIKE 'backoff:%'` 再啟動，或用 `auto-collect`（每 round 自動清）。
+- **Persisted backoff 會卡 OPGG seeding**：`source_family_backoff_until` 寫進 `crawl_runtime_state` 後，下一個 snowball 啟動時讀回，會印 `[snowball] startup skip  source=manual_riot_id  reason=backoff` 並讓整批 OPGG seed 不入 queue（newly_seeded=0）。先 `DELETE FROM crawl_runtime_state WHERE state_key LIKE 'backoff:%'` 再啟動。
 - **`source-family backoff` 出現 ≠ run 沒在生產**：backoff 只擋 fresh seeding，已在 queue 裡的 match-source 子節點繼續處理，rate 可能還是 ~30+/min。判 round 死活以 throughput 為準，不要看到 backoff 就 abort。
 
 ## NEVER

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ python -m pip install -e .
 ### 2. 跑 collector 一段時間
 最簡單一行（PowerShell 整段貼成一行）：
 ```powershell
-python scripts/lcu_collector.py auto-collect --rounds 50 --target-games 500 --max-players 1000 --opgg-tier platinum --opgg-tier gold
+python scripts/lcu_collector.py snowball --target-games 500 --max-players 1000 --games-per-player 4 --seed-ladder --seed-apex
 ```
 跑越久收越多。中斷再跑會自動續傳（SQLite + crawl frontier 都是持久化的）。
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ python -m pip install -e .   # 需要 Python 3.13+
 打開 League 客戶端（**不需要在玩**，登入在線即可），再開一個 PowerShell 視窗整段貼一行：
 
 ```powershell
-python scripts/lcu_collector.py auto-collect --rounds 50 --target-games 500 --max-players 1000 --opgg-tier platinum --opgg-tier gold
+python scripts/lcu_collector.py snowball --target-games 500 --max-players 1000 --games-per-player 4 --seed-ladder --seed-apex
 ```
 
 跑越久收越多場。任何時候 `Ctrl+C` 中斷都可以，下次再跑會從上次的進度續傳。想看現在累積到幾場：

--- a/scripts/lcu_collector.py
+++ b/scripts/lcu_collector.py
@@ -1622,8 +1622,8 @@ def export_share(
             f"  current dir: {cwd_abs}\n\n"
             "Most likely cause: you haven't collected any games yet.\n"
             "Run this first (with League client open in the background):\n\n"
-            "  python scripts/lcu_collector.py auto-collect --rounds 50 --target-games 500 "
-            "--max-players 1000 --opgg-tier platinum --opgg-tier gold\n\n"
+            "  python scripts/lcu_collector.py snowball --target-games 500 "
+            "--max-players 1000 --games-per-player 4 --seed-ladder --seed-apex\n\n"
             "Then re-run export-share. Or, if your DB lives elsewhere, pass --db <path-to-games.db>."
         )
 


### PR DESCRIPTION
## 摘要

[5335fa8](https://github.com/Lanternko/ARAM-Mayhem-Database/commit/5335fa8) 移除了 `auto-collect` 子指令並更新 README 頂端的 quick-start，但**留下 5 處殘留引用**指向已經不存在的指令。照著 [README.md L59](https://github.com/Lanternko/ARAM-Mayhem-Database/blob/main/README.md#L59)「每次貢獻」流程跑的新貢獻者，會在步驟 1 直接撞 `Error: No such command 'auto-collect'.`，整個貢獻流程被卡住。

## 在當前 `main` 重現

```powershell
python scripts/lcu_collector.py auto-collect --rounds 50 --target-games 500 --max-players 1000 --opgg-tier platinum --opgg-tier gold
# Error: No such command 'auto-collect'.
```

## 修法

把每處殘留引用都換成 5335fa8 自己在 README 頂端 quick-start 選用的 `snowball --seed-ladder --seed-apex`，所有入口指向同一個支援的流程。

| 位置 | 動作 |
|---|---|
| `README.md:59`（步驟 1） | 改成 snowball |
| `CONTRIBUTING.md:37`（步驟 2） | 改成 snowball |
| `CLAUDE.md:77`（指令清單） | 直接刪除 — 該檔 L63–67 已經有完整 snowball 範例 |
| `CLAUDE.md:103`（Stall Playbook） | 刪掉「或用 `auto-collect`」這段；前面的手動 SQL reset 還在 |
| `scripts/lcu_collector.py:1625`（export-share error） | 改成 snowball |

改完後 `git grep -n 'auto-collect\|auto_collect'` 全 repo 0 個 hit。

## 測試項目

- [x] `git grep` 確認 0 殘留引用
- [x] `python scripts/lcu_collector.py --help` 仍正常載入（無 syntax error）
- [x] 替換指令對齊 README 頂端 quick-start（5335fa8 自己選的，沿用維護者已表達的偏好）

🤖 由 [Claude Code](https://claude.com/claude-code) 協助產生